### PR TITLE
Fix error handling

### DIFF
--- a/ipfs-paste
+++ b/ipfs-paste
@@ -26,8 +26,19 @@ Darwin)
   clipaste="pbpaste"
   ;;
 Linux)
-  clicopy="xsel -i"
-  clipaste="xsel -o"
+  if type xsel >/dev/null;
+  then
+    clicopy="xsel -i"
+    clipaste="xsel -o"
+  else
+    if type xclip >/dev/null;
+    then
+      clicopy="xclip -i"
+      clipaste="xclip -o"
+    else
+      die "xsel or xclip is needed on Linux"
+    fi
+  fi
   ;;
 *) ;;
 esac

--- a/ipfs-paste
+++ b/ipfs-paste
@@ -1,6 +1,4 @@
 #!/bin/sh
-set -e
-set -o pipefail
 
 USAGE="$0 [-v] [--paste] [<name>]"
 

--- a/ipfs-paste
+++ b/ipfs-paste
@@ -96,4 +96,4 @@ log " copied\n"
 echo "$out"
 
 log "preloading on the gateways..."
-(curl "$out" 2>/dev/null >/dev/null && log " ok\n") || (true && log " n/a\n")
+(curl "$out" >/dev/null 2>&1 && log " ok\n") || log " n/a\n"

--- a/ipfs-paste
+++ b/ipfs-paste
@@ -64,23 +64,36 @@ fi
 if [ $paste ]; then
   test -n "$clipaste" || die "clipboard paste unkown for $(uname)"
   log "paste to ipfs..."
-  fhash=$($clipaste | ipfs add -q)
+
+  date=$(date +"%Y-%m-%dT%H:%M:%SZ")
+  fpath=$(mktemp "/tmp/paste.$date.XXXXXX.txt") ||
+  die "could not 'mktemp /tmp/paste.$date.XXXXXX.txt'"
+
+  $clipaste >"$fpath" ||
+  die "could not paste using '$clipaste'"
+  fhash=$(ipfs add -q <"$fpath") ||
+  die "could not 'ipfs add -q' content from '$fpath'"
 else
   log "stdin to ipfs..."
-  fhash=$(cat | ipfs add -q)
+  fhash=$(cat | ipfs add -q) ||
+  die "could not 'ipfs add -q'"
 fi
 log " $fhash\n"
 
 
 log "constructing dir..."
-dir=$(ipfs object new unixfs-dir)
-dir=$(ipfs object patch "$dir" add-link "$name" "$fhash" )
-pin=$(ipfs pin add -r "$dir")
+dir=$(ipfs object new unixfs-dir) ||
+die "could not 'ipfs object new unixfs-dir'"
+dir=$(ipfs object patch "$dir" add-link "$name" "$fhash") ||
+die "could not 'ipfs object patch $dir add-link $name $fhash'"
+pin=$(ipfs pin add -r "$dir") ||
+die "could not 'ipfs pin add -r $dir'"
 log " $dir\n"
 
 log "copying url to clipboard..."
 out="http://gateway.ipfs.io/ipfs/$dir/$name"
-echo "$out" | $clicopy
+echo "$out" | $clicopy ||
+die "could not copy using '$clicopy'"
 log " copied\n"
 echo "$out"
 


### PR DESCRIPTION
Use `die()` instead of `set -e` and `set -o pipefail` for error handling.
Also improve calling `curl`. And try `xclip` Linux.
